### PR TITLE
🐛 Fix a bug in getBestClustering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ from pydub import AudioSegment
 INPUT_FILE = "test.wav"
 
 sample_rate = 32000
-audio = AudioSegment.from_wav(test.wav)
+audio = AudioSegment.from_wav("test.wav")
 audio = audio.set_frame_rate(sample_rate)
 audio = audio.set_channels(1)
 

--- a/pydiar/models/binary_key/diarizationFunctions.py
+++ b/pydiar/models/binary_key/diarizationFunctions.py
@@ -438,16 +438,17 @@ def getBestClustering(
     vecToLine = vecFromFirst - vecFromFirstParallel
     distToLine = np.sqrt(np.sum(np.square(vecToLine), axis=1))
     bestClusteringID = allCoord[np.argmax(distToLine)][0]
+
+    # Select best clustering that matches max speaker limit
     nrSpeakersPerSolution = np.zeros((clusteringTable.shape[1]))
     for k in np.arange(clusteringTable.shape[1]):
         nrSpeakersPerSolution[k] = np.size(np.unique(clusteringTable[:, k]))
+
+    firstAllowedClustering = np.min(np.where(nrSpeakersPerSolution <= maxNrSpeakers))
+    # Note: clusters are ordered from most clusters to least, so this selects the bestClusteringID
+    # unless it has more than maxNrSpeakers nodes, in which case it selects firstAllowedClustering
     bestClusteringID = np.maximum(
-        np.where(
-            nrSpeakersPerSolution
-            == np.maximum(
-                np.minimum(maxNrSpeakers, np.max(nrSpeakersPerSolution)) - 1, 1
-            )
-        )[0][0],
+        firstAllowedClustering,
         bestClusteringID,
     )
     return bestClusteringID


### PR DESCRIPTION
This commit fixes a bug in getBestClustering which occured if no cluster was found that has the maximum number of speakers - 1. It also fixes an alleged logic-bug where getBestClustering would never return a clustering with the max number of speakers, but only maxNrSpeakers-1.

This could for example happen if the algorithm generates clusterings of sizes: `11, 9, 8, 7, 6, 5, 4, 3, 2, 1`. If `maxNrSpeakers` is >= 11 `np.maximum(
                np.minimum(maxNrSpeakers, np.max(nrSpeakersPerSolution)) - 1, 1
            )`  would return `10`. But there is no cluster that fulfills `nrSpeakersPerSolution
            == 10`, so `np.where` would return an empty list, which would lead to a crash in `np.maximum`