### PR TITLE
fix: `np.float` is deprecated

### DIFF
--- a/pydiar/util/sad.py
+++ b/pydiar/util/sad.py
@@ -111,7 +111,7 @@ def get_py_webrtcvad_segments(vad_info, fs):
     sad_info = np.column_stack((starts[1], ends[1]))
     vad_index = vad_index[0]
 
-    segments = np.zeros_like(sad_info, dtype=np.float)
+    segments = np.zeros_like(sad_info, dtype=float)
     for i in range(sad_info.shape[0]):
         segments[i][0] = float(vad_index[sad_info[i][0]]) / fs
         segments[i][1] = float(vad_index[sad_info[i][1]] + 1) / fs


### PR DESCRIPTION
It seems `numpy.float` is deprecated. I was getting the following error message. This PR replaces it according to the recommendation in the error message.

```
   File "/usr/local/lib/python3.9/site-packages/pydiar/util/sad.py", line 114, in get_py_webrtcvad_segments
     segments = np.zeros_like(sad_info, dtype=np.float)
                │  │          │               └ <module 'numpy' from '/usr/local/lib/python3.9/site-packages/numpy/__init__.py'>
                │  │          └ array([[     0, 164159],
                │  │                   [164160, 959379]])
                │  └ <function zeros_like at 0x7fcd715a2a60>
                └ <module 'numpy' from '/usr/local/lib/python3.9/site-packages/numpy/__init__.py'>
   File "/usr/local/lib/python3.9/site-packages/numpy/__init__.py", line 305, in __getattr__
     raise AttributeError(__former_attrs__[attr])
                          │                └ 'float'
                          └ {'object': "module 'numpy' has no attribute 'object'.\n`np.object` was a deprecated alias for the builtin `object
`. To avoid ...

 AttributeError: module 'numpy' has no attribute 'float'.
 `np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not
modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
 The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
     https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations


```